### PR TITLE
Update project dependencies / add doc

### DIFF
--- a/src/leiningen/new/chrome_extension.clj
+++ b/src/leiningen/new/chrome_extension.clj
@@ -21,6 +21,7 @@
              [(str "src/" sanitized "/popup.cljs") (render "popup.cljs" data)]
              [(str "src/" sanitized "/new_tab.cljs") (render "new_tab.cljs" data)]
              ["project.clj" (render "project.clj" data)]
+             ["README.md" (render "README.md" data)]
              ["resources/images/icon16.png" (binary "icon16.png")]
              ["resources/images/icon19.png" (binary "icon19.png")]
              ["resources/images/icon38.png" (binary "icon38.png")]

--- a/src/leiningen/new/chrome_extension/README.md
+++ b/src/leiningen/new/chrome_extension/README.md
@@ -1,0 +1,57 @@
+# {{ns-name}}
+
+FIXME: description
+
+## Installation
+
+FIXME: how to install
+
+## Usage
+
+FIXME: explanation
+
+## Options
+
+FIXME: listing of options this app accepts.
+
+## Examples
+
+...
+
+### Bugs
+
+...
+
+### Any Other Sections
+### That You Think
+### Might be Useful
+
+## License
+
+Copyright © 2016 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.
+
+
+### Coda
+
+The template for this project came from [lein-chrome-extension](https://github.com/clumsyjedi/lein-chrome-extension), and started with this command:
+
+`lein new chrome-extension {{ns-name}}`
+
+#### To build `target/{{sanitized}}.js`, run:
+
+`lein chromebuild once`
+
+#### To rebuild whenever a source file is modified, run:
+
+`lein chromebuild auto`
+
+#### To install your extension in Chrome:
+
+* Visit `chrome://extensions`
+* Click the `Developer mode` checkbox
+* Click the `Load unpacked extension ...` button
+* Select `target/{{sanitized}}.js`
+* Click the `Enable` checkbox

--- a/src/leiningen/new/chrome_extension/project.clj
+++ b/src/leiningen/new/chrome_extension/project.clj
@@ -1,15 +1,15 @@
 (defproject {{ns-name}} "0.1.0-SNAPSHOT"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2156"]
-                 [org.clojure/core.async "0.1.242.0-44b1e3-alpha"]
-                 [khroma "0.0.2"]
-                 [prismatic/dommy "0.1.2"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/clojurescript "1.9.89"]
+                 [org.clojure/core.async "0.2.385"]
+                 [khroma "0.3.0"]
+                 [prismatic/dommy "1.0.0"]]
   :source-paths ["src"]
   :profiles {:dev
-             {:plugins [[com.cemerick/austin "0.1.3"]
-                        [lein-cljsbuild "1.0.1"]
+             {:plugins [[com.cemerick/austin "0.1.6"]
+                        [lein-cljsbuild "1.1.3"]
                         [lein-chromebuild "0.3.0"]]
               :cljsbuild
               {:builds


### PR DESCRIPTION
- Updated project dependencies in the emitted project.cj
- Versions are the latest stable version as of June 10, 2016
- Added a README.md with some notes about lein-chrome-extension itself,
  and some general info for developers using lein-chrome-extension.
